### PR TITLE
fix tarball url

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -24,10 +24,13 @@ export ZOPEN_TYPE="TARBALL"
 #  - git: required by build.sh to be able to apply patches
 # Many packages will require basic tools like m4, make.      
 #
+# Regarding the URL for the binaries.  Using ../releases/download.. vs raw/main...
+# The releases version picks the first version.  The raw will pick the last version.
+#
 # zotsample 1.0
 # export ZOPEN_TARBALL_URL="https://github.com/ZOSOpenTools/zotsampleport/releases/download/zotsample-1.0/zotsample-1.0.tar.gz"
 # zotsample 1.1
-export ZOPEN_TARBALL_URL="https://github.com/ZOSOpenTools/zotsampleport/releases/download/zotsample-1.1/zotsample-1.1.tar.gz"
+export ZOPEN_TARBALL_URL="https://github.com/ZOSOpenTools/zotsampleport/raw/main/tarballs/zotsample-1.1.tar.gz"
 #
 export ZOPEN_TARBALL_DEPS="curl gzip make tar zoslib"
 


### PR DESCRIPTION
This fixes the failure with the url pulling the first revision of the binary.  I created the first version prior to knowing about the gentar script.  I did a `tar -cvzf foo.tar.gz` which normally works.  Not sure why it fails on USS though.

I made a comment in the file regarding the URL difference between releases and raw.

